### PR TITLE
Using data volume containers for caching gems

### DIFF
--- a/rails-pg-fig-devenv/Dockerfile
+++ b/rails-pg-fig-devenv/Dockerfile
@@ -1,1 +1,13 @@
-FROM rails:onbuild
+FROM ruby:2.1.5
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+RUN apt-get update && apt-get install -y nodejs --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y mysql-client postgresql-client sqlite3 --no-install-recommends && rm -rf /var/lib/apt/lists/*
+
+ENV GEM_HOME /usr/local/bundle
+ENV PATH $GEM_HOME/bin:$PATH
+
+EXPOSE 3000
+CMD ["rails", "server"]

--- a/rails-pg-fig-devenv/Dockerfile
+++ b/rails-pg-fig-devenv/Dockerfile
@@ -3,11 +3,17 @@ FROM ruby:2.1.5
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
-RUN apt-get update && apt-get install -y nodejs --no-install-recommends && rm -rf /var/lib/apt/lists/*
-RUN apt-get update && apt-get install -y mysql-client postgresql-client sqlite3 --no-install-recommends && rm -rf /var/lib/apt/lists/*
-
 ENV GEM_HOME /usr/local/bundle
 ENV PATH $GEM_HOME/bin:$PATH
+
+# Installing common RoR dependencies: Node.js and database clients
+# Remove the clients you don't use and modify to your needs.
+RUN apt-get update && apt-get install -y --no-install-recommends nodejs && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      mysql-client \
+      postgresql-client \
+      sqlite3 \
+    && rm -rf /var/lib/apt/lists/*
 
 EXPOSE 3000
 CMD ["rails", "server"]

--- a/rails-pg-fig-devenv/fig.yml
+++ b/rails-pg-fig-devenv/fig.yml
@@ -1,7 +1,7 @@
 db:
   image: postgres:9.3
-  volumes:
-    - ~/.docker-volumes/app-name/db/:/var/lib/postgresql/data/
+  volumes_from:
+    - APP_NAME-db-data
   ports:
     - 5432
 web:
@@ -9,7 +9,9 @@ web:
   command: bundle exec unicorn -p 3000 -c ./config/unicorn.rb
   volumes:
     - .:/usr/src/app
+  volumes_from:
+    - gems-RUBY_VERSION
   ports:
-    - 3000:3000
+    - "3000:3000"
   links:
     - db

--- a/rails-pg-fig-devenv/project.sh
+++ b/rails-pg-fig-devenv/project.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+
+# Fancy prints
+print_normal (){ printf "%b\n" "$1" >&2; }
+print_error  (){ printf "$(tput setaf 1)[fig-tree] %b$(tput sgr0)\n" "$1" >&2; }
+print_info   (){ printf "$(tput setaf 3)[fig-tree] %b$(tput sgr0)\n" "$1" >&2; }
+print_success(){ printf "$(tput setaf 2)[fig-tree] %b$(tput sgr0)\n" "$1" >&2; }
+
+# Abort in the case of an error
+handle_error(){
+  if [ $1 -ne 0 ]; then
+    print_error "Something went wrong while $2, aborting."
+    exit 1
+  fi
+}
+
+## CUSTOMIZE
+RUBY_VERSION=2.1
+APP_NAME=app-name
+PORT=3000
+
+custom_bootstrap(){
+  # Custom bootstrap instructions go here.
+  # This is the last bootstrap step; it is run after the first `bundle install`.
+  # Since this application has a db, you'll probably want to `rake db:setup`.
+  print_info "Setting up the database (rake db:setup)"
+  fig run web bundle exec rake db:setup
+  handle_error $? "setting up the database"
+}
+## /CUSTOMIZE
+
+DOCKER_MINIMAL_IMAGE=tianon/true
+GEMS_CONTAINER_NAME=gems-$RUBY_VERSION
+DB_DATA_CONTAINER_NAME=$APP_NAME-db-data
+FIG_PREFIX=$(echo ${PWD##*/} | tr -d '-')
+
+# `docker info` call for testing if the Docker host is reachable.
+# Usage: check_docker
+check_docker(){
+  docker info > /dev/null 2>&1
+  if [ $? -ne 0 ]; then
+    print_error "ERROR: Docker host could not be reached. Maybe you need sudo?"
+    exit 1
+  fi
+}
+
+# Create a data volume container for a specific path.
+# Usage: create_data_container CONTAINER_NAME VOLUME_PATH
+create_data_container(){
+  docker run -d --name $1 -v $2 $DOCKER_MINIMAL_IMAGE
+}
+
+# Stop a container by name.
+# Usage: stop_container_by_name CONTAINER_NAME
+stop_container_by_name(){
+  docker ps -a | grep $1 | awk '{ print $1 }' | xargs --no-run-if-empty docker stop
+}
+
+# Remove a container by name.
+# Usage: remove_container_by_name CONTAINER_NAME
+remove_container_by_name(){
+  docker ps -a | grep $1 | awk '{ print $1 }' | xargs --no-run-if-empty docker rm
+}
+
+# Remove an image by name.
+# Usage: remove_image_by_name IMAGE_NAME
+remove_image_by_name(){
+  docker images -a | grep $1 | awk '{ print $3 }' | xargs --no-run-if-empty docker rmi
+}
+
+# Main options
+bootstrap(){
+  # Announcing
+  print_info "Bootstrapping $APP_NAME"
+  print_info "Ruby version: $RUBY_VERSION"
+
+  # Check if the Gems container already exists. If not, create it.
+  local GEMS_CONTAINER=$(docker ps -a | grep $GEMS_CONTAINER_NAME)
+  if [ -n "$GEMS_CONTAINER" ]; then
+    print_success "The gems container for Ruby $RUBY_VERSION ($GEMS_CONTAINER_NAME) already exists."
+  else
+    print_info "Creating the gems container for Ruby $RUBY_VERSION ($GEMS_CONTAINER_NAME)."
+    create_data_container $GEMS_CONTAINER_NAME "/usr/local/bundle"
+    handle_error $? "creating $GEMS_CONTAINER_NAME"
+    print_success "Gems container for Ruby $RUBY_VERSION ($GEMS_CONTAINER_NAME) successfully created."
+  fi
+
+  # Check if the database data container already exists. If not, create it.
+  if [ -n "$(docker ps -a | grep $DB_DATA_CONTAINER_NAME)" ]; then
+    print_success "The database data container ($DB_DATA_CONTAINER_NAME) already exists."
+  else
+    print_info "Creating the database data container ($DB_DATA_CONTAINER_NAME)."
+    create_data_container $DB_DATA_CONTAINER_NAME "/var/lib/postgresql/data/"
+    handle_error $? "creating $DB_DATA_CONTAINER_NAME"
+    print_success "Database data container ($DB_DATA_CONTAINER_NAME) successfully created."
+  fi
+
+  # Build the web container
+  print_info "Building the web container."
+  fig build web
+  handle_error $? "building the web container"
+
+  # Check if the gems container was just created; if so, install bundler.
+  if [ -z "$GEMS_CONTAINER" ]; then
+    print_info "Gems container is new, installing bundler."
+    fig run web gem install bundler
+    handle_error $? "installing bundler"
+  else
+    print_info "Gems container already existed before this script: assuming bundler is already installed."
+    print_info "In the case of failure, run"
+    print_info "  fig run web gem install bundler"
+    print_info "and re-run this script."
+  fi
+
+  # Install app's dependencies
+  print_normal
+  print_info "Installing dependencies (bundle install)"
+  fig run web bundle install --jobs 4 --retry 3
+  handle_error $? "installing the app's dependencies"
+
+  custom_bootstrap
+
+  print_normal
+  print_success "The project was successfully setup! Run"
+  print_success "  $0 start"
+  print_success "to start the server."
+}
+
+start(){
+  # Assume Docker host is localhost, override in the case boot2docker is detected
+  local URL=http://localhost:$PORT/
+  command -v boot2docker > /dev/null 2>&1 && URL=http://$(boot2docker ip 2> /dev/null):$PORT/
+
+  print_info "Open $URL on your browser."
+  print_normal
+
+  fig up
+}
+
+bundle_exec(){
+  # Teaching fig commands, one at a time.
+  local command=$(echo ${@})
+  print_info "Running"
+  print_info "  fig run web bundle exec $command"
+  fig run web bundle exec $command
+}
+
+stop(){
+  fig stop
+  fig rm
+}
+
+clean(){
+  stop_container_by_name $FIG_PREFIX
+  remove_container_by_name $FIG_PREFIX
+  remove_image_by_name $FIG_PREFIX
+}
+
+project_clean(){
+  clean
+  remove_container_by_name $DB_DATA_CONTAINER_NAME
+}
+
+gems_clean(){
+  remove_container_by_name $GEMS_CONTAINER_NAME
+}
+
+untagged_clean(){
+  remove_image_by_name '^<none>' 2> /dev/null
+}
+
+check_docker
+case "$1" in
+  "bootstrap")
+    bootstrap
+  ;;
+
+  "start")
+    start
+  ;;
+
+  "exec")
+    bundle_exec ${@:2}
+  ;;
+
+  "console")
+    bundle_exec "rails console" ${@:2}
+  ;;
+
+  "stop")
+    stop
+  ;;
+
+  "clean")
+    clean
+  ;;
+
+  "project-clean")
+    project_clean
+  ;;
+
+  "gems-clean")
+    gems_clean
+  ;;
+
+  "untagged-clean")
+    untagged_clean
+  ;;
+
+  *)
+    print_normal "Usage: $0 COMMAND"
+    print_normal
+    print_normal "Available commands:"
+    print_normal "  bootstrap"
+    print_normal "  start"
+    print_normal "  exec"
+    print_normal "  console"
+    print_normal "  clean"
+    print_normal "  project-clean"
+    print_normal "  gems-clean"
+    print_normal "  untagged-clean"
+  ;;
+esac
+
+exit 0


### PR DESCRIPTION
Keeping the dependencies outside of the app container allows us to update the
Gemfile without the need for re-building the container again; this speeds up
`bundle install` and `bundle update` calls.

By keeping them in a data volume container we are able to reuse them across
multiple projects, which allows us to save disk space.

This approach aims to solve the `bundle install` issue of the previous version.
Because it relies on data volume containers that have to be created outside of
Fig (so the `fig rm` doesn't remove them), a script file is provided to aid the
process of bootstrapping a project (project.sh). The README.md was updated to
provide with the needed instructions and the `fig.yml` file adapted accordingly.
